### PR TITLE
Allow obj_update to not actually do any saves

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,8 @@ python:
 # Generate this env list with:
 # tox -l | awk '{ print "  - TOX_ENV="$0}'
 env:
-  - TOX_ENV=django110-py27
   - TOX_ENV=django110-py34
   - TOX_ENV=django110-py36
-  - TOX_ENV=django111-py27
   - TOX_ENV=django111-py34
   - TOX_ENV=django111-py36
   - TOX_ENV=django20-py34

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ test: ## Run test suite
 	PYTHONPATH=. django-admin.py test --settings=test_settings
 
 tdd: ## Run test suite with a watcher
-	nodemon -e py -x "make test"
+	nodemon -e py -x "make test || true"
 
 clean: ## Remove temporary files
 	rm -rf MANIFEST

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,9 @@ help: ## Shows this help
 test: ## Run test suite
 	PYTHONPATH=. django-admin.py test --settings=test_settings
 
+tdd: ## Run test suite with a watcher
+	nodemon -e py -x "make test"
+
 clean: ## Remove temporary files
 	rm -rf MANIFEST
 	rm -rf build

--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,20 @@ Updating an object
     for obj in queryset:
         obj_update(obj, new_data)
 
-Updating an object
+Dry run updating an object
+''''''''''''''''''''''''''
+
+::
+
+    from obj_update import obj_update
+
+    logger.setLevel(logging.DEBUG)  # see "Logging changes" below
+
+    new_data = {
+        'flavor': 'chocolate',
+    }
+    for obj in queryset:
+        obj_update(obj, new_data, save=False)
 
 Replacement for ``update_or_create``
 ''''''''''''''''''''''''''''''''''''

--- a/README.rst
+++ b/README.rst
@@ -35,6 +35,8 @@ Updating an object
     for obj in queryset:
         obj_update(obj, new_data)
 
+Updating an object
+
 Replacement for ``update_or_create``
 ''''''''''''''''''''''''''''''''''''
 
@@ -58,7 +60,7 @@ Using ``python-json-logger``::
     import logging
     from pythonjsonlogger.jsonlogger import JsonFormatter
 
-    logger = logger.getLogger('obj_update')
+    logger = logging.getLogger('obj_update')
     handler = logging.FileHandler('log/my_obj_changes.log')
     handler.setFormatter(JsonFormatter())
     logger.addHandler(handler)

--- a/obj_update.py
+++ b/obj_update.py
@@ -53,7 +53,7 @@ def json_log_formatter(dirty_data):
             for x in dirty_data}
 
 
-def obj_update(obj, data):
+def obj_update(obj, data, *, save=True):
     """
     Fancy way to update `obj` with `data` dict.
 
@@ -75,7 +75,8 @@ def obj_update(obj, data):
             }
         )
         update_fields = list(map(itemgetter('field_name'), dirty_data))
-        obj.save(update_fields=update_fields)
+        if save:
+            obj.save(update_fields=update_fields)
         delattr(obj, DIRTY)
         return True
 

--- a/obj_update.py
+++ b/obj_update.py
@@ -1,8 +1,5 @@
-from __future__ import unicode_literals
-
 from operator import itemgetter
 import logging
-import sys
 
 
 __all__ = ['obj_update', 'obj_update_or_create']
@@ -11,9 +8,6 @@ __version__ = '0.2.1'
 
 DIRTY = '_is_dirty'
 
-
-# for python 2/3 compatibility
-text_type = unicode if sys.version_info[0] < 3 else str  # noqa: F821
 
 logger = logging.getLogger('obj_update')
 
@@ -28,8 +22,8 @@ def set_field(obj, field_name, value):
         old_repr = None if old is None else getattr(old, 'pk', old)
         new_repr = None if value is None else getattr(value, 'pk', value)
     else:
-        old_repr = None if old is None else text_type(old)
-        new_repr = None if value is None else text_type(value)
+        old_repr = None if old is None else str(old)
+        new_repr = None if value is None else str(value)
     if old_repr != new_repr:
         setattr(obj, field_name, value)
         if not hasattr(obj, DIRTY):

--- a/setup.py
+++ b/setup.py
@@ -17,8 +17,6 @@ setup(
         "Intended Audience :: Developers",
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
-        "Programming Language :: Python :: 2",
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.6',

--- a/test_obj_update.py
+++ b/test_obj_update.py
@@ -28,6 +28,14 @@ class UpdateTests(TestCase):
         foo = FooModel.objects.get(pk=foo.pk)
         self.assertEqual(foo.text, 'hello2')
 
+    def test_can_update_fields_but_not_save(self):
+        foo = FooModel.objects.create(text='hello')
+
+        with self.assertNumQueries(0):
+            obj_update(foo, {'text': 'hello2'}, save=False)
+
+        self.assertEqual(foo.text, 'hello2')
+
     def test_no_changes_mean_no_queries(self):
         # setup
         foo = FooModel.objects.create(text='hello')

--- a/test_obj_update.py
+++ b/test_obj_update.py
@@ -1,11 +1,7 @@
 from __future__ import unicode_literals
 
 from decimal import Decimal
-try:
-    from StringIO import StringIO
-except ImportError:
-    # Python 3
-    from io import StringIO
+from io import StringIO
 import datetime
 import json
 import logging
@@ -16,7 +12,7 @@ from pythonjsonlogger.jsonlogger import JsonFormatter
 
 from test_app.models import FooModel, BarModel
 
-from obj_update import obj_update, obj_update_or_create, text_type
+from obj_update import obj_update, obj_update_or_create
 
 logger = logging.getLogger('obj_update')
 handler = logging.StreamHandler()
@@ -94,7 +90,7 @@ class UpdateTests(TestCase):
         # setup
         foo = FooModel.objects.create(datetime='2029-09-20 01:02:03')
         # sanity check
-        self.assertIsInstance(foo.datetime, text_type)
+        self.assertIsInstance(foo.datetime, str)
 
         with self.assertNumQueries(0):
             # 0 because input is exactly the same
@@ -129,7 +125,7 @@ class UpdateTests(TestCase):
         # setup
         foo = FooModel.objects.create(decimal='10.1')
         # sanity check
-        self.assertIsInstance(foo.decimal, text_type)
+        self.assertIsInstance(foo.decimal, str)
 
         with self.assertNumQueries(0):
             # 0 because input is exactly the same

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
-    django110-{py27,py34,py36},
-    django111-{py27,py34,py36},
+    django110-{py34,py36},
+    django111-{py34,py36},
     django20-{py34,py36},
 downloadcache = {toxworkdir}/.cache
 skipsdist = True


### PR DESCRIPTION
The diff logging is pretty useful on it's own. Sometimes, you want output from that without actually doing a save.