### PR TITLE
Logging tweaks

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -78,3 +78,11 @@ Using ``python-json-logger``::
     handler.setFormatter(JsonFormatter())
     logger.addHandler(handler)
     logger.setLevel(logging.DEBUG)
+
+With JSON logging, you'll get messages like::
+
+    {"message": "[text hello->hello2]", "model": "FooModel", "pk": 1, "changes": {"text": {"old": "hello", "new": "hello2"}}}
+
+With a normal logger, you'll still get output, but it won't have as much information::
+
+    [text hello->hello2]

--- a/obj_update.py
+++ b/obj_update.py
@@ -74,11 +74,9 @@ def obj_update(obj, data, *, save=True):
     logger.debug(
         human_log_formatter(dirty_data),
         extra={
-            'obj_update': {
-                'model': obj._meta.object_name,
-                'pk': obj.pk,
-                'changes': json_log_formatter(dirty_data),
-            },
+            'model': obj._meta.object_name,
+            'pk': obj.pk,
+            'changes': json_log_formatter(dirty_data),
         }
     )
     update_fields = list(map(itemgetter('field_name'), dirty_data))
@@ -94,8 +92,10 @@ def obj_update_or_create(model, defaults=None, **kwargs):
     """
     obj, created = model.objects.get_or_create(defaults=defaults, **kwargs)
     if created:
-        logger.debug('CREATED {} {}'.format(model._meta.object_name, obj.pk),
-                     extra={'obj_update': {'pk': obj.pk}})
+        logger.debug('CREATED %s %s',
+                     model._meta.object_name,
+                     obj.pk,
+                     extra={'pk': obj.pk})
     else:
         obj_update(obj, defaults)
     return obj, created

--- a/test_obj_update.py
+++ b/test_obj_update.py
@@ -71,13 +71,13 @@ class UpdateTests(TestCase):
         logged_lines = log_output.readlines()
         message_logged = json.loads(logged_lines[0])
         self.assertEqual(
-            message_logged['obj_update']['model'], 'FooModel')
+            message_logged['model'], 'FooModel')
         self.assertEqual(
-            message_logged['obj_update']['pk'], foo.pk)
+            message_logged['pk'], foo.pk)
         self.assertEqual(
-            message_logged['obj_update']['changes']['text']['old'], 'hello')
+            message_logged['changes']['text']['old'], 'hello')
         self.assertEqual(
-            message_logged['obj_update']['changes']['text']['new'], 'hello2')
+            message_logged['changes']['text']['new'], 'hello2')
 
         logger.removeHandler(test_handler)
         logger.addHandler(handler)


### PR DESCRIPTION
1. we were putting the extra in `obj_update`, but we don't need it because we already have our own logger
2. take advantage of formatting `%s` shortcuts built into Python logger
3. README updates

closes #6 