### PR TITLE
Better datetime comparison

### DIFF
--- a/obj_update.py
+++ b/obj_update.py
@@ -12,6 +12,10 @@ DIRTY = '_is_dirty'
 logger = logging.getLogger('obj_update')
 
 
+def my_repr(v):
+    return str(v)
+
+
 def set_field(obj, field_name, value):
     """Fancy setattr with debugging."""
     old = getattr(obj, field_name)
@@ -22,8 +26,8 @@ def set_field(obj, field_name, value):
         old_repr = None if old is None else getattr(old, 'pk', old)
         new_repr = None if value is None else getattr(value, 'pk', value)
     else:
-        old_repr = None if old is None else str(old)
-        new_repr = None if value is None else str(value)
+        old_repr = None if old is None else my_repr(old)
+        new_repr = None if value is None else my_repr(value)
     if old_repr != new_repr:
         setattr(obj, field_name, value)
         if not hasattr(obj, DIRTY):

--- a/obj_update.py
+++ b/obj_update.py
@@ -15,9 +15,9 @@ logger = logging.getLogger('obj_update')
 
 def datetime_repr(value):
     if isinstance(value, dt.datetime):
-        return value.isoformat()
+        return value.isoformat().replace('+00:00', 'Z')
 
-    return str(value)
+    return str(value).replace(' ', 'T')
 
 
 def set_field(obj, field_name, value):

--- a/test_obj_update.py
+++ b/test_obj_update.py
@@ -96,6 +96,10 @@ class UpdateTests(TestCase):
         with self.assertNumQueries(0):
             obj_update(foo, {'datetime': '2029-09-20 01:02:03'})
 
+        with self.assertNumQueries(0):
+            obj_update(foo, {'datetime': '2029-09-20T01:02:03'})
+
+
     def test_datetime_is_set(self):
         foo = FooModel.objects.create(datetime=dt.datetime(2029, 9, 20, 1, 2, 3))
         with self.assertNumQueries(1):

--- a/test_obj_update.py
+++ b/test_obj_update.py
@@ -2,7 +2,7 @@ from __future__ import unicode_literals
 
 from decimal import Decimal
 from io import StringIO
-import datetime
+import datetime as dt
 import json
 import logging
 import os
@@ -86,40 +86,20 @@ class UpdateTests(TestCase):
     # MODEL FIELD TYPES
     ###################
 
-    def test_datetime_init_as_str(self):
-        # setup
-        foo = FooModel.objects.create(datetime='2029-09-20 01:02:03')
-        # sanity check
-        self.assertIsInstance(foo.datetime, str)
-
+    def test_datetime_vs_datetime(self):
+        foo = FooModel.objects.create(datetime=dt.datetime(2029, 9, 20, 1, 2, 3))
         with self.assertNumQueries(0):
-            # 0 because input is exactly the same
+            obj_update(foo, {'datetime': dt.datetime(2029, 9, 20, 1, 2, 3)})
+
+    def test_datetime_vs_str(self):
+        foo = FooModel.objects.create(datetime=dt.datetime(2029, 9, 20, 1, 2, 3))
+        with self.assertNumQueries(0):
             obj_update(foo, {'datetime': '2029-09-20 01:02:03'})
 
-        with self.assertNumQueries(0):
-            # 0 because input is python type that reprs the same
-            obj_update(foo, {'datetime': datetime.datetime(2029, 9, 20, 1, 2, 3)})
-
-        with self.assertNumQueries(0):
-            # 1 because input looks close, but not quite close enough
-            obj_update(foo, {'datetime': '2029-09-20T01:02:03'})
-
-    def test_datetime_init_as_datetime(self):
-        # setup
-        foo = FooModel.objects.create(datetime=datetime.datetime(2029, 9, 20, 1, 2, 3))
-        # sanity check
-        self.assertIsInstance(foo.datetime, datetime.datetime)
-
-        with self.assertNumQueries(0):
-            # 0 because input is exactly the same
-            obj_update(foo, {'datetime': datetime.datetime(2029, 9, 20, 1, 2, 3)})
-
-        with self.assertNumQueries(0):
-            # 0 because input is python type that reprs the same
-            obj_update(foo, {'datetime': '2029-09-20 01:02:03'})
-
+    def test_datetime_is_set(self):
+        foo = FooModel.objects.create(datetime=dt.datetime(2029, 9, 20, 1, 2, 3))
         with self.assertNumQueries(1):
-            obj_update(foo, {'datetime': datetime.datetime(1111, 1, 1, 1, 1, 1)})
+            obj_update(foo, {'datetime': dt.datetime(1111, 1, 1, 1, 1, 1)})
 
     def test_decimal_a_text(self):
         # setup

--- a/test_obj_update.py
+++ b/test_obj_update.py
@@ -99,6 +99,13 @@ class UpdateTests(TestCase):
         with self.assertNumQueries(0):
             obj_update(foo, {'datetime': '2029-09-20T01:02:03'})
 
+    def test_datetime_updates_str(self):
+        foo = FooModel.objects.create(datetime=dt.datetime(2029, 9, 20, 1, 2, 3))
+        with self.assertNumQueries(1):
+            obj_update(foo, {'datetime': '2029-04-20 03:14:15'})
+
+        with self.assertNumQueries(1):
+            obj_update(foo, {'datetime': '2029-04-01T03:14:15'})
 
     def test_datetime_is_set(self):
         foo = FooModel.objects.create(datetime=dt.datetime(2029, 9, 20, 1, 2, 3))

--- a/test_obj_update.py
+++ b/test_obj_update.py
@@ -100,7 +100,7 @@ class UpdateTests(TestCase):
             # 0 because input is python type that reprs the same
             obj_update(foo, {'datetime': datetime.datetime(2029, 9, 20, 1, 2, 3)})
 
-        with self.assertNumQueries(1):
+        with self.assertNumQueries(0):
             # 1 because input looks close, but not quite close enough
             obj_update(foo, {'datetime': '2029-09-20T01:02:03'})
 


### PR DESCRIPTION
this fixes a longstanding TODO where comparing dates was really picky. This makes it slightly less picky, but if you're specifying iso8601 format. 

Currently not handling timezones since the my sqlite config doesn't understand them.