### PR TITLE
chore: format Python using Black

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,3 +20,9 @@ matrix:
       env: TOX_ENV=django110-py34
 install: pip install tox
 script: tox -e $TOX_ENV
+
+branches:
+  only:
+    - master
+notifications:
+  email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+cache: pip
 dist: xenial
 matrix:
   include:

--- a/LICENSE
+++ b/LICENSE
@@ -192,7 +192,7 @@ APPENDIX: How to apply the Apache License to your work
     on the same "printed page" as the copyright notice for easier
     identification within third-party archives.
 
-        Copyright 2015 Chris Chang
+        Copyright [yyyy] [name of copyright owner]
 
         Licensed under the Apache License, Version 2.0 (the "License");
         you may not use this file except in compliance with the License.

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,9 @@ test: ## Run test suite
 tdd: ## Run test suite with a watcher
 	nodemon -e py -x "make test || true"
 
+lint: ## Check for lint errors
+	black . --check
+
 clean: ## Remove temporary files
 	rm -rf MANIFEST
 	rm -rf build

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 # Dev dependencies
+black
 Django
 python-json-logger
 tox

--- a/setup.py
+++ b/setup.py
@@ -2,21 +2,21 @@ from setuptools import setup
 
 
 setup(
-    name='dj-obj-update',
-    version='0.5.0',
+    name="dj-obj-update",
+    version="0.5.0",
     author="Chris Chang",
-    author_email='c@crccheck.com',
+    author_email="c@crccheck.com",
     url="https://github.com/crccheck/dj-obj-update",
-    py_modules=['obj_update'],
-    license='Apache License, Version 2.0',
-    description='A Django app for adding object tools for models in the admin',
-    long_description=open('README.rst').read(),
+    py_modules=["obj_update"],
+    license="Apache License, Version 2.0",
+    description="A Django app for adding object tools for models in the admin",
+    long_description=open("README.rst").read(),
     classifiers=[
-        'Development Status :: 4 - Beta',
+        "Development Status :: 4 - Beta",
         "Framework :: Django",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
-        'Programming Language :: Python :: 3',
+        "Programming Language :: Python :: 3",
     ],
 )

--- a/test_app/models.py
+++ b/test_app/models.py
@@ -8,11 +8,11 @@ class FooModel(models.Model):
     decimal = models.DecimalField(max_digits=5, decimal_places=2, null=True)
     slug = models.SlugField(max_length=5, null=True)
     text = models.TextField(null=True)
-    foreignkey = models.ForeignKey('BarModel', null=True, on_delete=models.CASCADE)
+    foreignkey = models.ForeignKey("BarModel", null=True, on_delete=models.CASCADE)
     created = models.DateTimeField(auto_now_add=True)
     updated = models.DateTimeField(auto_now=True)
 
 
 class BarModel(models.Model):
     def __str__(self):
-        raise NotImplementedError('update should not be looking at repr')
+        raise NotImplementedError("update should not be looking at repr")

--- a/test_app/settings.py
+++ b/test_app/settings.py
@@ -1,21 +1,18 @@
 DEBUG = True
 DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'HOST': '',
-        'NAME': ':memory:',
-        'PASSWORD': '',
-        'PORT': '',
-        'USER': '',
-    },
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "HOST": "",
+        "NAME": ":memory:",
+        "PASSWORD": "",
+        "PORT": "",
+        "USER": "",
+    }
 }
 
-INSTALLED_APPS = (
-    'django.contrib.contenttypes',  # to be slightly realistic
-    'test_app',
-)
+INSTALLED_APPS = ("django.contrib.contenttypes", "test_app")  # to be slightly realistic
 
-SECRET_KEY = 'hunter2'
+SECRET_KEY = "hunter2"
 
 # STFU
-SILENCED_SYSTEM_CHECKS = ('1_7.W001', )
+SILENCED_SYSTEM_CHECKS = ("1_7.W001",)

--- a/test_obj_update.py
+++ b/test_obj_update.py
@@ -13,61 +13,61 @@ from test_app.models import FooModel, BarModel
 
 from obj_update import obj_update, obj_update_or_create
 
-logger = logging.getLogger('obj_update')
+logger = logging.getLogger("obj_update")
 handler = logging.StreamHandler()
 handler.setFormatter(JsonFormatter())
 logger.addHandler(handler)
-logger.setLevel(getattr(logging, os.getenv('LOG_LEVEL', 'CRITICAL')))
+logger.setLevel(getattr(logging, os.getenv("LOG_LEVEL", "CRITICAL")))
 
 
 class UpdateTests(TestCase):
     def test_can_update_fields(self):
-        foo = FooModel.objects.create(text='hello')
+        foo = FooModel.objects.create(text="hello")
 
         with self.assertNumQueries(1):
-            obj_update(foo, {'text': 'hello2'})
+            obj_update(foo, {"text": "hello2"})
 
         foo.refresh_from_db()
-        self.assertEqual(foo.text, 'hello2')
+        self.assertEqual(foo.text, "hello2")
 
     def test_can_update_fields_but_not_save(self):
-        foo = FooModel.objects.create(text='hello')
+        foo = FooModel.objects.create(text="hello")
 
         with self.assertNumQueries(0):
-            obj_update(foo, {'text': 'hello2'}, update_fields=[])
+            obj_update(foo, {"text": "hello2"}, update_fields=[])
 
-        self.assertEqual(foo.text, 'hello2')
+        self.assertEqual(foo.text, "hello2")
 
     def test_can_update_fields_but_not_save_DEPRECATED(self):
-        foo = FooModel.objects.create(text='hello')
+        foo = FooModel.objects.create(text="hello")
 
         with self.assertNumQueries(0):
-            obj_update(foo, {'text': 'hello2'}, save=False)
+            obj_update(foo, {"text": "hello2"}, save=False)
 
-        self.assertEqual(foo.text, 'hello2')
+        self.assertEqual(foo.text, "hello2")
 
     def test_update_fields_stuff(self):
-        foo = FooModel(text='hello')
+        foo = FooModel(text="hello")
         # Sanity check: fails without update_fields
         with transaction.atomic(), self.assertRaises(ValueError):
-            obj_update(foo, {'text': 'hello2'})
+            obj_update(foo, {"text": "hello2"})
 
         with self.assertNumQueries(1):
-            obj_update(foo, {'text': 'hello2'}, update_fields=None)
+            obj_update(foo, {"text": "hello2"}, update_fields=None)
 
         foo.refresh_from_db()
-        self.assertEqual(foo.text, 'hello2')
+        self.assertEqual(foo.text, "hello2")
         self.assertTrue(foo.id)
 
     def test_no_changes_mean_no_queries(self):
         # setup
-        foo = FooModel.objects.create(text='hello')
+        foo = FooModel.objects.create(text="hello")
 
         with self.assertNumQueries(0):
-            obj_update(foo, {'text': 'hello'})
+            obj_update(foo, {"text": "hello"})
 
         with self.assertNumQueries(0):
-            obj_update(foo, {'text': u'hello'})
+            obj_update(foo, {"text": u"hello"})
 
         # FIXME? This fails in Python 3
         # with self.assertNumQueries(0):
@@ -83,25 +83,21 @@ class UpdateTests(TestCase):
         logger.removeHandler(handler)
         logger.addHandler(test_handler)
         logger.setLevel(logging.DEBUG)
-        foo = FooModel.objects.create(text='hello')
+        foo = FooModel.objects.create(text="hello")
 
-        obj_update(foo, {'text': 'hello2'})
+        obj_update(foo, {"text": "hello2"})
 
         log_output.seek(0)
         logged_lines = log_output.readlines()
         message_logged = json.loads(logged_lines[0])
-        self.assertEqual(
-            message_logged['model'], 'FooModel')
-        self.assertEqual(
-            message_logged['pk'], foo.pk)
-        self.assertEqual(
-            message_logged['changes']['text']['old'], 'hello')
-        self.assertEqual(
-            message_logged['changes']['text']['new'], 'hello2')
+        self.assertEqual(message_logged["model"], "FooModel")
+        self.assertEqual(message_logged["pk"], foo.pk)
+        self.assertEqual(message_logged["changes"]["text"]["old"], "hello")
+        self.assertEqual(message_logged["changes"]["text"]["new"], "hello2")
 
         logger.removeHandler(test_handler)
         logger.addHandler(handler)
-        logger.setLevel(getattr(logging, os.getenv('LOG_LEVEL', 'CRITICAL')))
+        logger.setLevel(getattr(logging, os.getenv("LOG_LEVEL", "CRITICAL")))
 
     # MODEL FIELD TYPES
     ###################
@@ -109,94 +105,94 @@ class UpdateTests(TestCase):
     def test_datetime_vs_datetime(self):
         foo = FooModel.objects.create(datetime=dt.datetime(2029, 9, 20, 1, 2, 3))
         with self.assertNumQueries(0):
-            obj_update(foo, {'datetime': dt.datetime(2029, 9, 20, 1, 2, 3)})
+            obj_update(foo, {"datetime": dt.datetime(2029, 9, 20, 1, 2, 3)})
 
     def test_datetime_vs_str(self):
         foo = FooModel.objects.create(datetime=dt.datetime(2029, 9, 20, 1, 2, 3))
         with self.assertNumQueries(0):
-            obj_update(foo, {'datetime': '2029-09-20 01:02:03'})
+            obj_update(foo, {"datetime": "2029-09-20 01:02:03"})
 
         with self.assertNumQueries(0):
-            obj_update(foo, {'datetime': '2029-09-20T01:02:03'})
+            obj_update(foo, {"datetime": "2029-09-20T01:02:03"})
 
     def test_datetime_updates_str(self):
         foo = FooModel.objects.create(datetime=dt.datetime(2029, 9, 20, 1, 2, 3))
         with self.assertNumQueries(1):
-            obj_update(foo, {'datetime': '2029-04-20 03:14:15'})
+            obj_update(foo, {"datetime": "2029-04-20 03:14:15"})
 
         with self.assertNumQueries(1):
-            obj_update(foo, {'datetime': '2029-04-01T03:14:15'})
+            obj_update(foo, {"datetime": "2029-04-01T03:14:15"})
 
     def test_datetime_is_set(self):
         foo = FooModel.objects.create(datetime=dt.datetime(2029, 9, 20, 1, 2, 3))
         with self.assertNumQueries(1):
-            obj_update(foo, {'datetime': dt.datetime(1111, 1, 1, 1, 1, 1)})
+            obj_update(foo, {"datetime": dt.datetime(1111, 1, 1, 1, 1, 1)})
 
     def test_decimal_a_text(self):
         # setup
-        foo = FooModel.objects.create(decimal='10.1')
+        foo = FooModel.objects.create(decimal="10.1")
         # sanity check
         self.assertIsInstance(foo.decimal, str)
 
         with self.assertNumQueries(0):
             # 0 because input is exactly the same
-            obj_update(foo, {'decimal': '10.1'})
+            obj_update(foo, {"decimal": "10.1"})
 
         with self.assertNumQueries(0):
-            obj_update(foo, {'decimal': 10.1})
+            obj_update(foo, {"decimal": 10.1})
 
         with self.assertNumQueries(1):
-            obj_update(foo, {'decimal': 1.01})
+            obj_update(foo, {"decimal": 1.01})
 
         foo = FooModel.objects.get(pk=foo.pk)
-        self.assertEqual(foo.decimal, Decimal('1.01'))
+        self.assertEqual(foo.decimal, Decimal("1.01"))
 
     # is this any different from text?
     def test_slug(self):
         # setup
-        foo = FooModel.objects.create(slug='hello')
+        foo = FooModel.objects.create(slug="hello")
 
         with self.assertNumQueries(0):
-            obj_update(foo, {'slug': 'hello'})
+            obj_update(foo, {"slug": "hello"})
 
         with self.assertNumQueries(1):
-            obj_update(foo, {'slug': 'hello1'})
+            obj_update(foo, {"slug": "hello1"})
 
         foo = FooModel.objects.get(pk=foo.pk)
-        self.assertEqual(foo.slug, 'hello1')
+        self.assertEqual(foo.slug, "hello1")
 
     def test_text(self):
         # setup
-        foo = FooModel.objects.create(text='hello')
+        foo = FooModel.objects.create(text="hello")
 
         with self.assertNumQueries(0):
-            obj_update(foo, {'text': 'hello'})
+            obj_update(foo, {"text": "hello"})
 
         with self.assertNumQueries(1):
-            obj_update(foo, {'text': 'hello1'})
+            obj_update(foo, {"text": "hello1"})
 
         foo = FooModel.objects.get(pk=foo.pk)
-        self.assertEqual(foo.text, 'hello1')
+        self.assertEqual(foo.text, "hello1")
 
     def test_foreignkey_adding(self):
         foo = FooModel.objects.create(foreignkey=None)
         bar = BarModel.objects.create()
 
         with self.assertNumQueries(0):
-            obj_update(foo, {'foreignkey': None})
+            obj_update(foo, {"foreignkey": None})
 
         with self.assertNumQueries(1):
-            obj_update(foo, {'foreignkey': bar})
+            obj_update(foo, {"foreignkey": bar})
 
     def test_foreignkey_adding_as_id(self):
         foo = FooModel.objects.create(foreignkey=None)
         bar = BarModel.objects.create()
 
         with self.assertNumQueries(0):
-            obj_update(foo, {'foreignkey': None})
+            obj_update(foo, {"foreignkey": None})
 
         with self.assertNumQueries(1):
-            obj_update(foo, {'foreignkey_id': bar.pk})
+            obj_update(foo, {"foreignkey_id": bar.pk})
         foo = FooModel.objects.get(pk=foo.pk)
         self.assertEqual(foo.foreignkey, bar)
 
@@ -206,11 +202,11 @@ class UpdateTests(TestCase):
         foo = FooModel.objects.create(foreignkey=bar)
 
         with self.assertNumQueries(0):
-            obj_update(foo, {'foreignkey': bar})
+            obj_update(foo, {"foreignkey": bar})
         self.assertEqual(foo.foreignkey, bar)
 
         with self.assertNumQueries(1):
-            obj_update(foo, {'foreignkey': None})
+            obj_update(foo, {"foreignkey": None})
 
         foo = FooModel.objects.get(pk=foo.pk)
         self.assertEqual(foo.foreignkey, None)
@@ -219,29 +215,29 @@ class UpdateTests(TestCase):
         # setup
         bar1 = BarModel.objects.create()
         bar2 = BarModel.objects.create()
-        foo = FooModel.objects.create(text='hello', foreignkey=bar1)
+        foo = FooModel.objects.create(text="hello", foreignkey=bar1)
 
         with self.assertNumQueries(0):
-            obj_update(foo, {'foreignkey': bar1})
+            obj_update(foo, {"foreignkey": bar1})
         self.assertEqual(foo.foreignkey, bar1)
 
         with self.assertNumQueries(1):
-            obj_update(foo, {'foreignkey': bar2})
+            obj_update(foo, {"foreignkey": bar2})
         self.assertEqual(foo.foreignkey, bar2)
 
     def test_foreignkey_changing_as_id(self):
         # setup
         bar1 = BarModel.objects.create()
         bar2 = BarModel.objects.create()
-        foo = FooModel.objects.create(text='hello', foreignkey=bar1)
+        foo = FooModel.objects.create(text="hello", foreignkey=bar1)
 
         with self.assertNumQueries(0):
-            obj_update(foo, {'foreignkey_id': bar1.id})
+            obj_update(foo, {"foreignkey_id": bar1.id})
         foo = FooModel.objects.get(pk=foo.pk)
         self.assertEqual(foo.foreignkey, bar1)
 
         with self.assertNumQueries(1):
-            obj_update(foo, {'foreignkey_id': bar2.id})
+            obj_update(foo, {"foreignkey_id": bar2.id})
         foo = FooModel.objects.get(pk=foo.pk)
         self.assertEqual(foo.foreignkey, bar2)
 
@@ -253,32 +249,32 @@ class ObjUpdateOrCreateTests(TransactionTestCase):
             # 1. SELECT
             # 2. BEGIN
             # 3. INSERT
-            foo, created = obj_update_or_create(FooModel, text='hi', defaults={
-                'slug': 'leopard',
-            })
+            foo, created = obj_update_or_create(
+                FooModel, text="hi", defaults={"slug": "leopard"}
+            )
         self.assertTrue(created)
-        self.assertEqual(foo.text, 'hi')
-        self.assertEqual(foo.slug, 'leopard')
+        self.assertEqual(foo.text, "hi")
+        self.assertEqual(foo.slug, "leopard")
 
         # Test updating with nothing new
         with self.assertNumQueries(1):
             # 1. SELECT
-            foo, created = obj_update_or_create(FooModel, text='hi', defaults={
-                'slug': 'leopard',
-            })
+            foo, created = obj_update_or_create(
+                FooModel, text="hi", defaults={"slug": "leopard"}
+            )
         self.assertFalse(created)
-        self.assertEqual(foo.text, 'hi')
-        self.assertEqual(foo.slug, 'leopard')
+        self.assertEqual(foo.text, "hi")
+        self.assertEqual(foo.slug, "leopard")
 
         # Test updating with new data
         with self.assertNumQueries(3):
             # 1. SELECT
             # 2. BEGIN
             # 3. INSERT
-            foo, created = obj_update_or_create(FooModel, text='hi', defaults={
-                'slug': 'lemon', 'decimal': '0.01',
-            })
+            foo, created = obj_update_or_create(
+                FooModel, text="hi", defaults={"slug": "lemon", "decimal": "0.01"}
+            )
         self.assertFalse(created)
-        self.assertEqual(foo.text, 'hi')
-        self.assertEqual(foo.slug, 'lemon')
-        self.assertEqual(foo.decimal, '0.01')
+        self.assertEqual(foo.text, "hi")
+        self.assertEqual(foo.slug, "lemon")
+        self.assertEqual(foo.decimal, "0.01")


### PR DESCRIPTION
There's a lot of momentum to using [Black](https://github.com/psf/black). For example, [Django will use it](https://github.com/django/deps/blob/master/accepted/0008-black.rst)

This pulls the bandaid off to avoid mixing lint changes w/ code changes in the future. I opted to not dictate how Black is run because I'm not 100% sure how that should happen. To make sure PRs contributors are following this, I added a lint check in CI.