### PR TITLE
fix test case that broke in Django 2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,13 @@
 language: python
 cache: pip
 dist: xenial
-matrix:
+install: pip install tox
+script: tox -e $TOX_ENV
+
+jobs:
   include:
+    - python: 3.7
+      env: TOX_ENV=django22-py37
     - python: 3.7
       env: TOX_ENV=django21-py37
     - python: 3.6
@@ -19,8 +24,6 @@ matrix:
       env: TOX_ENV=django111-py34
     - python: 3.4
       env: TOX_ENV=django110-py34
-install: pip install tox
-script: tox -e $TOX_ENV
 
 branches:
   only:

--- a/test_obj_update.py
+++ b/test_obj_update.py
@@ -5,6 +5,7 @@ import json
 import logging
 import os
 
+import django
 from django.db import transaction
 from django.test import TestCase, TransactionTestCase
 from pythonjsonlogger.jsonlogger import JsonFormatter
@@ -267,9 +268,10 @@ class ObjUpdateOrCreateTests(TransactionTestCase):
         self.assertEqual(foo.slug, "leopard")
 
         # Test updating with new data
-        with self.assertNumQueries(3):
+        num_queries = 3 if django.VERSION < (2, 2) else 2
+        with self.assertNumQueries(num_queries):
             # 1. SELECT
-            # 2. BEGIN
+            # 2. BEGIN if Django<2.2  Django no longer always starts a transaction when a single query is being performed https://docs.djangoproject.com/en/2.2/releases/2.2/
             # 3. INSERT
             foo, created = obj_update_or_create(
                 FooModel, text="hi", defaults={"slug": "lemon", "decimal": "0.01"}

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist =
     django111-{py34,py36},
     django20-{py34,py36},
     django21-{py35,py37},
+    django22-{py37},
 downloadcache = {toxworkdir}/.cache
 skipsdist = True
 
@@ -18,3 +19,4 @@ deps =
     django111: Django<1.12
     django20: Django<2.1
     django21: Django<2.2
+    django22: Django<2.3


### PR DESCRIPTION
Django no longer always starts a transaction when a single query is being performed https://docs.djangoproject.com/en/2.2/releases/2.2/

This broke a test that counted SQL statements. I've adjusted the test do pick a number based on the Django version. We'll be able to delete it after we stop supporting Django 2.1