### PR TITLE
feat: split logging into create and update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 cache: pip
-dist: xenial
+dist: bionic
 install: pip install tox
 script: tox -e $TOX_ENV
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 cache: pip
-dist: bionic
+dist: xenial
 install: pip install tox
 script: tox -e $TOX_ENV
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-Django Object Update
-====================
+# Django Object Update
 
 [![Build Status](https://travis-ci.org/crccheck/dj-obj-update.svg?branch=master)](https://travis-ci.org/crccheck/dj-obj-update)
 
@@ -10,15 +9,11 @@ an object:
 2.  Log what changed (the logger name is `obj_update` and only outputs
     `logging.DEBUG`)
 
-
-Installation
-------------
+## Installation
 
     pip install dj-obj-update
 
-
-Usage
------
+## Usage
 
 ### Updating an object
 
@@ -76,11 +71,11 @@ Using `python-json-logger`:
     logger.addHandler(handler)
     logger.setLevel(logging.DEBUG)
 
-With JSON logging, you\'ll get messages like:
+With JSON logging, you'll get messages like:
 
     {"message": "[text hello->hello2]", "model": "FooModel", "pk": 1, "changes": {"text": {"old": "hello", "new": "hello2"}}}
 
-With a normal logger, you\'ll still get output, but it won\'t have as
-much information:
+With a normal logger, you'll still get output, but it won't have as much
+information:
 
     [text hello->hello2]

--- a/README.md
+++ b/README.md
@@ -83,5 +83,5 @@ information:
 You can selectively log object creation or updates. For example, if you don't
 expect objects to be created, you can only enable the `obj_update.create`
 logger. Likewise, you can only enable the `obj_update.update` logger to ignore
-creation. See [test_obj_update](./test_obj_update) for an example logging
-config.
+creation. See the `logging.config` example at the top of
+[test_obj_update](./test_obj_update) for an example.

--- a/README.md
+++ b/README.md
@@ -79,3 +79,9 @@ With a normal logger, you'll still get output, but it won't have as much
 information:
 
     [text hello->hello2]
+
+You can selectively log object creation or updates. For example, if you don't
+expect objects to be created, you can only enable the `obj_update.create`
+logger. Likewise, you can only enable the `obj_update.update` logger to ignore
+creation. See [test_obj_update](./test_obj_update) for an example logging
+config.

--- a/obj_update.py
+++ b/obj_update.py
@@ -2,9 +2,9 @@
 `dj-obj-update` helps you update an object but only saves if something changed.
 """
 
-from operator import itemgetter
 import datetime as dt
 import logging
+from operator import itemgetter
 from unittest.mock import sentinel
 
 __all__ = ["obj_update", "obj_update_or_create"]

--- a/obj_update.py
+++ b/obj_update.py
@@ -15,7 +15,8 @@ DIRTY = "_is_dirty"
 UNSET = sentinel.UNSET
 
 
-logger = logging.getLogger("obj_update")
+create_logger = logging.getLogger("obj_update.create")
+update_logger = logging.getLogger("obj_update.update")
 
 
 def datetime_repr(value):
@@ -92,7 +93,7 @@ def obj_update(obj, data: dict, *, update_fields=UNSET, save: bool = True) -> bo
     if not dirty_data:
         return False
 
-    logger.debug(
+    update_logger.debug(
         human_log_formatter(dirty_data),
         extra={
             "model": obj._meta.object_name,
@@ -115,8 +116,8 @@ def obj_update_or_create(model, defaults=None, update_fields=UNSET, **kwargs):
     """
     obj, created = model.objects.get_or_create(defaults=defaults, **kwargs)
     if created:
-        logger.debug(
-            "CREATED %s %s", model._meta.object_name, obj.pk, extra={"pk": obj.pk}
+        create_logger.debug(
+            "Created %s %s", model._meta.object_name, obj.pk, extra={"pk": obj.pk}
         )
     else:
         obj_update(obj, defaults, update_fields=update_fields)

--- a/test_obj_update.py
+++ b/test_obj_update.py
@@ -17,31 +17,24 @@ from test_app.models import FooModel, BarModel
 
 from obj_update import obj_update, obj_update_or_create
 
-logger = logging.getLogger("obj_update")
-# handler = logging.StreamHandler()
-# handler.setFormatter(JsonFormatter())
-# logger.addHandler(handler)
-# logger.setLevel(getattr(logging, os.getenv("LOG_LEVEL", "CRITICAL")))
-# logger2 = logging.getLogger("obj_update.create")
-# logger2.propagate = False
-# handler2 = logging.StreamHandler()
-# handler2.setFormatter(JsonFormatter())
-# logger2.addHandler(handler2)
-# logger2.setLevel(logging.DEBUG)
 logging.config.dictConfig(
     {
         "version": 1,
         "formatters": {
             "json": {
-                #    'format':
-                "class": "pythonjsonlogger.jsonlogger.JsonFormatter"
+                "class": "pythonjsonlogger.jsonlogger.JsonFormatter",
             },
-            # "human": {},
         },
         "handlers": {
-            "console": {"class": "logging.StreamHandler", "formatter": "json"}
+            "console": {"class": "logging.StreamHandler", "formatter": "json"},
+            "null": {"class": "logging.NullHandler", "formatter": "json"},
         },
-        "loggers": {"obj_update": {"level": "INFO", "handlers": ["console"],}},
+        "loggers": {
+            # Edit this config to play with these to test different logging scenarios
+            "obj_update": {"level": "DEBUG", "handlers": ["null"]},
+            # "obj_update.create": {"level": "DEBUG", "handlers": ["console"]},
+            # "obj_update.update": {"level": "DEBUG", "handlers": ["console"]},
+        },
     }
 )
 

--- a/test_obj_update.py
+++ b/test_obj_update.py
@@ -1,9 +1,12 @@
 import datetime as dt
 import json
 import logging.config
+import sys
+import unittest
 import os
 from decimal import Decimal
 from io import StringIO
+from unittest import skipIf
 
 import django
 from django.db import transaction
@@ -99,18 +102,19 @@ class UpdateTests(TestCase):
     # LOGGING
     #########
 
+    @unittest.skipIf(sys.version_info < (3, 4, 0), 'Requires Python 3.4 or greater')
     def test_logging(self):
         foo = FooModel.objects.create(text="hello")
 
-        with self.assertLogs('obj_update', level='DEBUG') as cm:
+        with self.assertLogs("obj_update", level="DEBUG") as cm:
             obj_update(foo, {"text": "hello2"})
 
         self.assertEqual(len(cm.records), 1)
         record = cm.records[0]
-        self.assertEqual(record.model, 'FooModel')
+        self.assertEqual(record.model, "FooModel")
         self.assertEqual(record.pk, foo.pk)
-        self.assertEqual(record.changes['text']['old'], 'hello')
-        self.assertEqual(record.changes['text']['new'], 'hello2')
+        self.assertEqual(record.changes["text"]["old"], "hello")
+        self.assertEqual(record.changes["text"]["new"], "hello2")
 
     # MODEL FIELD TYPES
     ###################

--- a/test_obj_update.py
+++ b/test_obj_update.py
@@ -1,14 +1,10 @@
 import datetime as dt
-import json
 import logging.config
-import os
 from decimal import Decimal
-from io import StringIO
 
 import django
 from django.db import transaction
 from django.test import TestCase, TransactionTestCase
-from pythonjsonlogger.jsonlogger import JsonFormatter
 
 from test_app.models import FooModel, BarModel
 

--- a/test_obj_update.py
+++ b/test_obj_update.py
@@ -13,9 +13,7 @@ from obj_update import obj_update, obj_update_or_create
 logging.config.dictConfig(
     {
         "version": 1,
-        "formatters": {
-            "json": {"class": "pythonjsonlogger.jsonlogger.JsonFormatter"},
-        },
+        "formatters": {"json": {"class": "pythonjsonlogger.jsonlogger.JsonFormatter"}},
         "handlers": {
             "console": {"class": "logging.StreamHandler", "formatter": "json"},
             "null": {"class": "logging.NullHandler", "formatter": "json"},

--- a/test_obj_update.py
+++ b/test_obj_update.py
@@ -14,9 +14,7 @@ logging.config.dictConfig(
     {
         "version": 1,
         "formatters": {
-            "json": {
-                "class": "pythonjsonlogger.jsonlogger.JsonFormatter",
-            },
+            "json": {"class": "pythonjsonlogger.jsonlogger.JsonFormatter"},
         },
         "handlers": {
             "console": {"class": "logging.StreamHandler", "formatter": "json"},

--- a/test_obj_update.py
+++ b/test_obj_update.py
@@ -1,12 +1,9 @@
 import datetime as dt
 import json
 import logging.config
-import sys
-import unittest
 import os
 from decimal import Decimal
 from io import StringIO
-from unittest import skipIf
 
 import django
 from django.db import transaction
@@ -95,7 +92,6 @@ class UpdateTests(TestCase):
     # LOGGING
     #########
 
-    @unittest.skipIf(sys.version_info < (3, 4, 0), 'Requires Python 3.4 or greater')
     def test_logging(self):
         foo = FooModel.objects.create(text="hello")
 

--- a/test_obj_update.py
+++ b/test_obj_update.py
@@ -1,9 +1,9 @@
-from decimal import Decimal
-from io import StringIO
 import datetime as dt
 import json
 import logging
 import os
+from decimal import Decimal
+from io import StringIO
 
 import django
 from django.db import transaction


### PR DESCRIPTION
When using this, a "create" might be unusual while "update" may not be (or vice-versa). If you want logging for just one of those, you can enable logging for `obj_update.create` or `obj_update.update`. Both events go to `obj_update` so you can continue to use that level too.